### PR TITLE
chore: update the .NET version of the Dockerfile to match csproj

### DIFF
--- a/src/OAuch/Dockerfile
+++ b/src/OAuch/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 WORKDIR /OAuch
 
 # Copy everything
@@ -11,7 +11,7 @@ RUN dotnet publish -c Release -o docker-build
 RUN dotnet dev-certs https
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /OAuch
 COPY --from=build-env /OAuch/docker-build .
 # Copy the HTTPS certificates from the build environment


### PR DESCRIPTION
The docker build currently fails, because the .NET version is too old.

This PR fixes this.