### PR TITLE
fix: throw an exception when an http request takes more than 5s

### DIFF
--- a/src/OAuch/OAuch.Protocols/Http/HttpHelper.cs
+++ b/src/OAuch/OAuch.Protocols/Http/HttpHelper.cs
@@ -170,8 +170,11 @@ namespace OAuch.Protocols.Http {
         }
         private static async Task<HttpResponse> ReadResponse(WebRequest request, ParameterMule mule) {
             try {
-                using var response = await request.GetResponseAsync();
+                using var response = await request.GetResponseAsync().WaitAsync(TimeSpan.FromSeconds(5));
                 return await ReadResponse(response as HttpWebResponse, mule);
+            } catch (TimeoutException) {
+                request.Abort();
+                throw;
             } catch (WebException we) {
                 if (we.Response is not HttpWebResponse er)
                     throw;


### PR DESCRIPTION
When a server only listens on port 443, an http request on port 80 will hang forever, preventing the test from going further.

Disclaimer: I have very little experience with C#/.NET and used an LLM to recommend a fix.