### PR TITLE
ci: add github-actions to publish multi-arch container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish container image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch: # for manual trigger
+
+jobs:
+  build-and-publish:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get the code
+      uses: actions/checkout@v6
+
+    - name: Get .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Build x64 container image (without publishing)
+      if: github.ref_type != 'tag'
+      working-directory: src/OAuch
+      run: |
+        dotnet publish --arch x64
+
+    - name: Build and publish x64 and arm64 images
+      if: github.ref_type == 'tag'
+      working-directory: src/OAuch
+      env:
+          DOTNET_CONTAINER_REGISTRY_UNAME: ${{ github.actor }}
+          DOTNET_CONTAINER_REGISTRY_PWORD: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        dotnet publish -t:PublishContainer \
+          -p:RuntimeIdentifiers='"linux-x64;linux-arm64"' \
+          -p:ContainerRegistry=ghcr.io \
+          -p:ContainerRepository=${{ github.repository }} \
+          -p:ContainerImageTags='"latest;${{ github.ref_name }}"'

--- a/src/OAuch/OAuch/OAuch.csproj
+++ b/src/OAuch/OAuch/OAuch.csproj
@@ -27,6 +27,9 @@
     <None Remove="oauch.db-wal" />
     <None Remove="oauch.db-wal.org" />
     <None Remove="oauch.db.org" />
+    <ContainerEnvironmentVariable
+      Include="ASPNETCORE_ENVIRONMENT"
+      Value="Container" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/OAuch/OAuch/appsettings.Container.json
+++ b/src/OAuch/OAuch/appsettings.Container.json
@@ -1,0 +1,15 @@
+{
+  "Kestrel": {
+    "Endpoints": {
+      "Https": {
+        // rootless container cannot bind to ports < 1024
+        // https://devblogs.microsoft.com/dotnet/securing-containers-with-rootless/#switching-to-port-8080
+        "Url": "http://*:8080",
+        "Protocols": "Http1"
+      }
+    }
+  },
+  "ConnectionStrings": {
+    "OAuchDbContextConnection": "Data Source=/home/app/oauch.db;"
+  }
+}

--- a/src/OAuch/OAuch/appsettings.Docker.json
+++ b/src/OAuch/OAuch/appsettings.Docker.json
@@ -1,5 +1,0 @@
-{
-  "ConnectionStrings": {
-    "OAuchDbContextConnection": "Data Source=/db/oauch.db;"
-  }
-}


### PR DESCRIPTION
As proposed in #10

Instead of using the `Dockerfile`, this leverages the `dotnet publish` command to build multi-arch (x64 and arm64) container images.

- on push to `main`, the container is built for x64 (smoke test, to ensure that the docker build is not broken)
- on tag, the container is built and published for x64 and arm64 (multi-image arch, so the callers don't have to worry about it)

This works fine, but I had to adjust 2 aspects:

## Sqlite DB path change

`/app` is owned by an [user different from the user running the app](https://github.com/richlander/container-workshop/blob/main/super-sql-app/control-container-runtime.md), so the sqlite db can't be created there. I **moved it to `/home/app`** (this also allows consumers to set a volume for the whole `/home/app` without messing with the dll).

## Https -> http

Generating self-signed certs in a previous step is a bit hacky (self-signed certs are easy to misuse and the expiry date is like a time-bomb).

I think that https certs should be managed outside of the docker container (reverse-proxy for instance).

Since dotnet defaults to rootless containers, the **app now accepts http requests on port 8080**.

---

You can try the current state on https://github.com/oliverpool/OAuch/pkgs/container/oauch

```
docker  run -p 8080:8080 ghcr.io/oliverpool/oauch:main
```